### PR TITLE
[Feature #29] add category and categoryNotification

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -74,7 +74,6 @@ kover {
 
 tasks.withType<Test> {
     useJUnitPlatform()
-
 }
 tasks.named("test") {
     finalizedBy("koverVerify")

--- a/api/src/main/kotlin/com/project/api/internal/Enum.kt
+++ b/api/src/main/kotlin/com/project/api/internal/Enum.kt
@@ -8,6 +8,7 @@ enum class ErrorMessage(
     NOT_FOUND_USER("해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_GROUP("해당 그룹을 찾을 수 없습니다."),
     NOT_FOUND_GROUP_USER("해당 그룹 회원을 찾을 수 없습니다."),
+    NOT_FOUND_CATEGORY("해당 카테고리를 찾을 수 없습니다."),
     NEW_PASSWORD_MATCH_OLD_PASSWORD("새로운 패스워드가 이전 패스워드와 일치합니다."),
     IMPOSSIBLE_LOGIN("로그인이 불가능합니다. 관리자에게 문의해주세요"),
     IMPOSSIBLE_PASSWORD("이전 비밀번호와 다른 비밀번호로 설정해주세요"),
@@ -19,5 +20,5 @@ enum class EmailForm(
     val subject: String,
     val message: String,
 ) {
-    VERIFY_EMAIL("[DevToolKit] 본인인증 코드","고객님의 본인인증 코드는 다음과 같습니다.")
+    VERIFY_EMAIL("[DevToolKit] 본인인증 코드", "고객님의 본인인증 코드는 다음과 같습니다."),
 }

--- a/api/src/main/kotlin/com/project/api/repository/category/CategoryNotificationRepository.kt
+++ b/api/src/main/kotlin/com/project/api/repository/category/CategoryNotificationRepository.kt
@@ -1,0 +1,13 @@
+package com.project.api.repository.category
+
+import com.project.core.domain.category.Category
+import com.project.core.domain.category.CategoryNotification
+import com.project.core.domain.group.GroupUser
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CategoryNotificationRepository : JpaRepository<CategoryNotification, Long> {
+    fun findByCategoryAndGroupUser(
+        category: Category,
+        groupUser: GroupUser,
+    ): CategoryNotification?
+}

--- a/api/src/main/kotlin/com/project/api/repository/category/CategoryRepository.kt
+++ b/api/src/main/kotlin/com/project/api/repository/category/CategoryRepository.kt
@@ -1,0 +1,9 @@
+package com.project.api.repository.category
+
+import com.project.core.domain.category.Category
+import com.project.core.domain.group.Group
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CategoryRepository : JpaRepository<Category, Long> {
+    fun findByGroup(group: Group): List<Category>
+}

--- a/api/src/main/kotlin/com/project/api/repository/group/GroupUserRepository.kt
+++ b/api/src/main/kotlin/com/project/api/repository/group/GroupUserRepository.kt
@@ -9,7 +9,6 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor
 interface GroupUserRepository :
     JpaRepository<GroupUser, Long>,
     QuerydslPredicateExecutor<GroupUser> {
-
     fun findByUserAndGroup(
         user: User,
         group: Group,

--- a/api/src/main/kotlin/com/project/api/service/CategoryNotificationService.kt
+++ b/api/src/main/kotlin/com/project/api/service/CategoryNotificationService.kt
@@ -1,4 +1,4 @@
-package com.project.api.web.api
+package com.project.api.service
 
 import com.project.api.commons.exception.RestException
 import com.project.api.internal.ErrorMessage
@@ -54,7 +54,7 @@ class CategoryNotificationService(
             groupUserRepository.findByUserAndGroup(user, group)
                 ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP_USER.message)
 
-        if(!groupUser.role.isActive()) {
+        if (!groupUser.role.isActive()) {
             throw RestException.authorized(ErrorMessage.UNAUTHORIZED.message)
         }
 
@@ -80,14 +80,21 @@ class CategoryNotificationService(
     }
 
     @Transactional
-    fun update(group: Group, groupUser: GroupUser, type: CategoryNotificationType,) {
-        categoryRepository.findByGroup(group)
+    fun update(
+        group: Group,
+        groupUser: GroupUser,
+        type: CategoryNotificationType,
+    ) {
+        categoryRepository
+            .findByGroup(group)
             .map { category ->
-                categoryNotificationRepository.findByCategoryAndGroupUser(
-                    category, groupUser
-                )?.apply {
-                    this.type = type
-                }?: run {
+                categoryNotificationRepository
+                    .findByCategoryAndGroupUser(
+                        category,
+                        groupUser,
+                    )?.apply {
+                        this.type = type
+                    } ?: run {
                     categoryNotificationRepository.save(
                         CategoryNotification(
                             category = category,

--- a/api/src/main/kotlin/com/project/api/service/CategoryService.kt
+++ b/api/src/main/kotlin/com/project/api/service/CategoryService.kt
@@ -6,7 +6,6 @@ import com.project.api.repository.category.CategoryRepository
 import com.project.api.repository.group.GroupRepository
 import com.project.api.repository.group.GroupUserRepository
 import com.project.api.repository.user.UserRepository
-import com.project.api.web.api.CategoryNotificationService
 import com.project.api.web.dto.request.CategoryCreateRequest
 import com.project.api.web.dto.request.CategoryUpdateRequest
 import com.project.api.web.dto.response.CategoryCreateResponse
@@ -92,7 +91,6 @@ class CategoryService(
             categoryRepository.findByIdOrNull(categoryId) ?: throw RestException.notFound(
                 ErrorMessage.NOT_FOUND_CATEGORY.message,
             )
-
 
         val groupUser =
             groupUserRepository.findByUserAndGroup(user, category.group)

--- a/api/src/main/kotlin/com/project/api/service/CategoryService.kt
+++ b/api/src/main/kotlin/com/project/api/service/CategoryService.kt
@@ -1,0 +1,105 @@
+package com.project.api.service
+
+import com.project.api.commons.exception.RestException
+import com.project.api.internal.ErrorMessage
+import com.project.api.repository.category.CategoryRepository
+import com.project.api.repository.group.GroupRepository
+import com.project.api.repository.group.GroupUserRepository
+import com.project.api.repository.user.UserRepository
+import com.project.api.web.api.CategoryNotificationService
+import com.project.api.web.dto.request.CategoryCreateRequest
+import com.project.api.web.dto.request.CategoryUpdateRequest
+import com.project.api.web.dto.response.CategoryCreateResponse
+import com.project.api.web.dto.response.CategoryCreateResponse.Companion.toCategoryCreateResponse
+import com.project.api.web.dto.response.CategoryUpdateResponse
+import com.project.api.web.dto.response.CategoryUpdateResponse.Companion.toCategoryUpdateResponse
+import com.project.core.domain.category.Category
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CategoryService(
+    private val categoryRepository: CategoryRepository,
+    private val userRepository: UserRepository,
+    private val groupUserRepository: GroupUserRepository,
+    private val categoryNotificationService: CategoryNotificationService,
+    private val groupRepository: GroupRepository,
+) {
+    @Transactional
+    fun create(
+        email: String,
+        request: CategoryCreateRequest,
+    ): CategoryCreateResponse {
+        val user = userRepository.findByEmail(email) ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
+        val group =
+            groupRepository.findByIdOrNull(request.groupId)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP.message)
+
+        val groupUser =
+            groupUserRepository.findByUserAndGroup(user, group)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP_USER.message)
+
+        if (!groupUser.role.isTopAmin()) throw RestException.authorized(ErrorMessage.UNAUTHORIZED.message)
+
+        return categoryRepository
+            .save(
+                Category(
+                    name = request.name,
+                    group = group,
+                    isPublic = request.isPublic,
+                ),
+            ).also {
+                categoryNotificationService.create(it, groupUser)
+            }.toCategoryCreateResponse(group.id)
+    }
+
+    @Transactional
+    fun update(
+        email: String,
+        request: CategoryUpdateRequest,
+    ): CategoryUpdateResponse {
+        val user = userRepository.findByEmail(email) ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
+        val group =
+            groupRepository.findByIdOrNull(request.groupId)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP.message)
+
+        val groupUser =
+            groupUserRepository.findByUserAndGroup(user, group)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP_USER.message)
+
+        if (!groupUser.role.isTopAmin()) throw RestException.authorized(ErrorMessage.UNAUTHORIZED.message)
+
+        val category =
+            categoryRepository.findByIdOrNull(request.categoryId) ?: throw RestException.notFound(
+                ErrorMessage.NOT_FOUND_CATEGORY.message,
+            )
+
+        return category
+            .apply {
+                this.name = request.name
+                this.isPublic = request.isPublic
+            }.toCategoryUpdateResponse(group.id)
+    }
+
+    @Transactional
+    fun delete(
+        email: String,
+        categoryId: Long,
+    ) {
+        val user = userRepository.findByEmail(email) ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
+        val category =
+            categoryRepository.findByIdOrNull(categoryId) ?: throw RestException.notFound(
+                ErrorMessage.NOT_FOUND_CATEGORY.message,
+            )
+
+
+        val groupUser =
+            groupUserRepository.findByUserAndGroup(user, category.group)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP_USER.message)
+
+        if (!groupUser.role.isTopAmin()) throw RestException.authorized(ErrorMessage.UNAUTHORIZED.message)
+
+        categoryRepository.delete(category)
+    }
+}

--- a/api/src/main/kotlin/com/project/api/service/GroupUserService.kt
+++ b/api/src/main/kotlin/com/project/api/service/GroupUserService.kt
@@ -5,6 +5,7 @@ import com.project.api.internal.ErrorMessage
 import com.project.api.repository.group.GroupRepository
 import com.project.api.repository.group.GroupUserRepository
 import com.project.api.repository.user.UserRepository
+import com.project.api.web.api.CategoryNotificationService
 import com.project.api.web.dto.request.GroupUserCreateRequest
 import com.project.api.web.dto.request.GroupUserUpdateRequest
 import com.project.api.web.dto.response.GroupRoleResponse
@@ -15,6 +16,7 @@ import com.project.api.web.dto.response.GroupUserResponse
 import com.project.api.web.dto.response.GroupUserResponse.Companion.toGroupUserResponse
 import com.project.core.domain.group.GroupUser
 import com.project.core.domain.group.QGroupUser
+import com.project.core.internal.CategoryNotificationType
 import com.project.core.internal.GroupRole
 import com.querydsl.core.BooleanBuilder
 import org.springframework.data.domain.Page
@@ -28,6 +30,7 @@ class GroupUserService(
     private val groupUserRepository: GroupUserRepository,
     private val groupRepository: GroupRepository,
     private val userRepository: UserRepository,
+    private val categoryNotificationService: CategoryNotificationService,
 ) {
     @Transactional
     fun create(
@@ -120,7 +123,11 @@ class GroupUserService(
                     this.role = request.role
                     this.isApproved = true
                 }
-            }.toGroupUserResponse()
+            }.also {
+                val categoryNotificationType = if(!request.role.isActive()) CategoryNotificationType.NONE else CategoryNotificationType.ALL
+                categoryNotificationService.update(group, groupUser, categoryNotificationType)
+            }
+            .toGroupUserResponse()
     }
 
     fun readRole(
@@ -174,4 +181,3 @@ class GroupUserService(
             }
     }
 }
-

--- a/api/src/main/kotlin/com/project/api/service/GroupUserService.kt
+++ b/api/src/main/kotlin/com/project/api/service/GroupUserService.kt
@@ -5,7 +5,6 @@ import com.project.api.internal.ErrorMessage
 import com.project.api.repository.group.GroupRepository
 import com.project.api.repository.group.GroupUserRepository
 import com.project.api.repository.user.UserRepository
-import com.project.api.web.api.CategoryNotificationService
 import com.project.api.web.dto.request.GroupUserCreateRequest
 import com.project.api.web.dto.request.GroupUserUpdateRequest
 import com.project.api.web.dto.response.GroupRoleResponse
@@ -124,10 +123,9 @@ class GroupUserService(
                     this.isApproved = true
                 }
             }.also {
-                val categoryNotificationType = if(!request.role.isActive()) CategoryNotificationType.NONE else CategoryNotificationType.ALL
+                val categoryNotificationType = if (!request.role.isActive()) CategoryNotificationType.NONE else CategoryNotificationType.ALL
                 categoryNotificationService.update(group, groupUser, categoryNotificationType)
-            }
-            .toGroupUserResponse()
+            }.toGroupUserResponse()
     }
 
     fun readRole(

--- a/api/src/main/kotlin/com/project/api/service/MailService.kt
+++ b/api/src/main/kotlin/com/project/api/service/MailService.kt
@@ -12,13 +12,13 @@ class MailService(
     fun send(
         email: String,
         code: String,
-        type: EmailForm
+        type: EmailForm,
     ) {
         val mailMessage =
             javaMailSender.createMimeMessage().apply {
                 setSubject(type.subject)
                 setText(
-                    type.message+"<br/> 코드 : $code",
+                    type.message + "<br/> 코드 : $code",
                     "UTF-8",
                     "html",
                 )

--- a/api/src/main/kotlin/com/project/api/service/UserService.kt
+++ b/api/src/main/kotlin/com/project/api/service/UserService.kt
@@ -29,9 +29,7 @@ class UserService(
     private val mailService: MailService,
     private val passwordEncoder: PasswordEncoder,
 ) {
-    fun verifyEmail(
-        email: String,
-    ): String {
+    fun verifyEmail(email: String): String {
         val code = UUID.randomUUID().toString().substring(0, 10)
         mailService.send(email, code, EmailForm.VERIFY_EMAIL)
         return code
@@ -69,23 +67,20 @@ class UserService(
             }
     }
 
-    fun findEmail(email: String,): Boolean {
-        return userRepository.existsByEmail(email)
-    }
+    fun findEmail(email: String): Boolean = userRepository.existsByEmail(email)
 
     @Transactional
-    fun resetPassword(
-        request: UserResetPasswordRequest,
-    ) {
-        val user = userRepository.findByEmail(request.email)
-            ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
+    fun resetPassword(request: UserResetPasswordRequest) {
+        val user =
+            userRepository.findByEmail(request.email)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
 
-        if(passwordEncoder.matches(request.newPassword, user.password)) {
+        if (passwordEncoder.matches(request.newPassword, user.password)) {
             throw RestException.badRequest(ErrorMessage.IMPOSSIBLE_PASSWORD.message)
         }
 
         userRepository.save(
-            user.apply { password = passwordEncoder.encode(request.newPassword) }
+            user.apply { password = passwordEncoder.encode(request.newPassword) },
         )
     }
 
@@ -168,4 +163,3 @@ class UserService(
         }
     }
 }
-

--- a/api/src/main/kotlin/com/project/api/web/api/CategoryController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/CategoryController.kt
@@ -1,0 +1,48 @@
+package com.project.api.web.api
+
+import com.project.api.service.CategoryService
+import com.project.api.web.dto.request.CategoryCreateRequest
+import com.project.api.web.dto.request.CategoryUpdateRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/categories")
+@Tag(name = "Category", description = "Category API")
+class CategoryController(
+    private val categoryService: CategoryService,
+) {
+    @PostMapping
+    @Operation(summary = "카테고리 생성")
+    fun create(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestBody request: CategoryCreateRequest,
+    ) = categoryService.create(jwt.subject, request)
+
+    @PatchMapping
+    @Operation(summary = "카테고리 수정")
+    fun update(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestBody request: CategoryUpdateRequest,
+    ) = categoryService.update(jwt.subject, request)
+
+    @DeleteMapping
+    @Operation(summary = "카테고리 삭제")
+    fun delete(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestParam categoryId: Long,
+    ): ResponseEntity<Unit> {
+        categoryService.delete(jwt.subject, categoryId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/api/src/main/kotlin/com/project/api/web/api/CategoryNotificationController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/CategoryNotificationController.kt
@@ -1,0 +1,23 @@
+package com.project.api.web.api
+
+import com.project.api.web.dto.request.CategoryNotificationUpdateRequest
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/categories-notification")
+class CategoryNotificationController(
+    private val categoryNotificationService: CategoryNotificationService,
+) {
+    @PatchMapping
+    @Operation(summary = "카테고리별 알림 설정 수정")
+    fun update(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestBody request: CategoryNotificationUpdateRequest,
+    ) = categoryNotificationService.update(jwt.subject, request)
+}

--- a/api/src/main/kotlin/com/project/api/web/api/CategoryNotificationController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/CategoryNotificationController.kt
@@ -1,5 +1,6 @@
 package com.project.api.web.api
 
+import com.project.api.service.CategoryNotificationService
 import com.project.api.web.dto.request.CategoryNotificationUpdateRequest
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/api/src/main/kotlin/com/project/api/web/api/CategoryNotificationService.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/CategoryNotificationService.kt
@@ -1,0 +1,101 @@
+package com.project.api.web.api
+
+import com.project.api.commons.exception.RestException
+import com.project.api.internal.ErrorMessage
+import com.project.api.repository.category.CategoryNotificationRepository
+import com.project.api.repository.category.CategoryRepository
+import com.project.api.repository.group.GroupRepository
+import com.project.api.repository.group.GroupUserRepository
+import com.project.api.repository.user.UserRepository
+import com.project.api.web.dto.request.CategoryNotificationUpdateRequest
+import com.project.api.web.dto.response.CategoryNotificationUpdateResponse
+import com.project.api.web.dto.response.CategoryNotificationUpdateResponse.Companion.toCategoryNotificationUpdateResponse
+import com.project.core.domain.category.Category
+import com.project.core.domain.category.CategoryNotification
+import com.project.core.domain.group.Group
+import com.project.core.domain.group.GroupUser
+import com.project.core.internal.CategoryNotificationType
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CategoryNotificationService(
+    private val categoryNotificationRepository: CategoryNotificationRepository,
+    private val categoryRepository: CategoryRepository,
+    private val userRepository: UserRepository,
+    private val groupUserRepository: GroupUserRepository,
+    private val groupRepository: GroupRepository,
+) {
+    @Transactional
+    fun create(
+        category: Category,
+        groupUser: GroupUser,
+    ) {
+        categoryNotificationRepository.save(
+            CategoryNotification(
+                category = category,
+                groupUser = groupUser,
+            ),
+        )
+    }
+
+    @Transactional
+    fun update(
+        email: String,
+        request: CategoryNotificationUpdateRequest,
+    ): CategoryNotificationUpdateResponse {
+        val user = userRepository.findByEmail(email) ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
+        val group =
+            groupRepository.findByIdOrNull(request.groupId)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP.message)
+
+        val groupUser =
+            groupUserRepository.findByUserAndGroup(user, group)
+                ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP_USER.message)
+
+        if(!groupUser.role.isActive()) {
+            throw RestException.authorized(ErrorMessage.UNAUTHORIZED.message)
+        }
+
+        val category =
+            categoryRepository.findByIdOrNull(request.categoryId) ?: throw RestException.notFound(
+                ErrorMessage.NOT_FOUND_CATEGORY.message,
+            )
+
+        val categoryNotification =
+            categoryNotificationRepository.findByCategoryAndGroupUser(category, groupUser)?.apply {
+                this.type = request.type
+            } ?: run {
+                categoryNotificationRepository.save(
+                    CategoryNotification(
+                        category = category,
+                        groupUser = groupUser,
+                        type = request.type,
+                    ),
+                )
+            }
+
+        return categoryNotification.toCategoryNotificationUpdateResponse(category.id)
+    }
+
+    @Transactional
+    fun update(group: Group, groupUser: GroupUser, type: CategoryNotificationType,) {
+        categoryRepository.findByGroup(group)
+            .map { category ->
+                categoryNotificationRepository.findByCategoryAndGroupUser(
+                    category, groupUser
+                )?.apply {
+                    this.type = type
+                }?: run {
+                    categoryNotificationRepository.save(
+                        CategoryNotification(
+                            category = category,
+                            groupUser = groupUser,
+                            type = type,
+                        ),
+                    )
+                }
+            }
+    }
+}

--- a/api/src/main/kotlin/com/project/api/web/api/GroupController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/GroupController.kt
@@ -55,4 +55,3 @@ class GroupController(
         return ResponseEntity.noContent().build()
     }
 }
-

--- a/api/src/main/kotlin/com/project/api/web/api/UserController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/UserController.kt
@@ -53,9 +53,7 @@ class UserController(
 
     @GetMapping("find-email")
     @Operation(summary = "아이디 찾기")
-    fun findEmail(
-        email: String,
-    ) = userService.findEmail(email)
+    fun findEmail(email: String) = userService.findEmail(email)
 
     @PatchMapping("reset-password")
     @Operation(summary = "비밀번호 찾기(재설정)")

--- a/api/src/main/kotlin/com/project/api/web/dto/request/CategoryCreateRequest.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/request/CategoryCreateRequest.kt
@@ -1,0 +1,7 @@
+package com.project.api.web.dto.request
+
+data class CategoryCreateRequest(
+    val groupId: Long,
+    val name: String,
+    val isPublic: Boolean,
+)

--- a/api/src/main/kotlin/com/project/api/web/dto/request/CategoryNotificationUpdateRequest.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/request/CategoryNotificationUpdateRequest.kt
@@ -1,0 +1,9 @@
+package com.project.api.web.dto.request
+
+import com.project.core.internal.CategoryNotificationType
+
+data class CategoryNotificationUpdateRequest(
+    val groupId: Long,
+    val categoryId: Long,
+    val type: CategoryNotificationType,
+)

--- a/api/src/main/kotlin/com/project/api/web/dto/request/CategoryUpdateRequest.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/request/CategoryUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.project.api.web.dto.request
+
+data class CategoryUpdateRequest(
+    val name: String,
+    val isPublic: Boolean,
+    val categoryId: Long,
+    val groupId: Long,
+)

--- a/api/src/main/kotlin/com/project/api/web/dto/response/CategoryCreateResponse.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/response/CategoryCreateResponse.kt
@@ -1,0 +1,20 @@
+package com.project.api.web.dto.response
+
+import com.project.core.domain.category.Category
+
+data class CategoryCreateResponse(
+    val groupId: Long?,
+    val categoryId: Long?,
+    val name: String,
+    val isPublic: Boolean,
+) {
+    companion object {
+        fun Category.toCategoryCreateResponse(groupId: Long?) =
+            CategoryCreateResponse(
+                groupId = groupId,
+                categoryId = this.id,
+                name = this.name,
+                isPublic = this.isPublic,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/project/api/web/dto/response/CategoryNotificationUpdateResponse.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/response/CategoryNotificationUpdateResponse.kt
@@ -1,6 +1,5 @@
 package com.project.api.web.dto.response
 
-import com.project.core.domain.category.Category
 import com.project.core.domain.category.CategoryNotification
 import com.project.core.internal.CategoryNotificationType
 
@@ -10,12 +9,11 @@ data class CategoryNotificationUpdateResponse(
     val type: CategoryNotificationType,
 ) {
     companion object {
-        fun CategoryNotification.toCategoryNotificationUpdateResponse(categoryId: Long?): CategoryNotificationUpdateResponse {
-            return CategoryNotificationUpdateResponse(
+        fun CategoryNotification.toCategoryNotificationUpdateResponse(categoryId: Long?): CategoryNotificationUpdateResponse =
+            CategoryNotificationUpdateResponse(
                 categoryId = categoryId,
                 categoryNotificationId = this.id,
-                type = this.type
+                type = this.type,
             )
-        }
     }
 }

--- a/api/src/main/kotlin/com/project/api/web/dto/response/CategoryNotificationUpdateResponse.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/response/CategoryNotificationUpdateResponse.kt
@@ -1,0 +1,21 @@
+package com.project.api.web.dto.response
+
+import com.project.core.domain.category.Category
+import com.project.core.domain.category.CategoryNotification
+import com.project.core.internal.CategoryNotificationType
+
+data class CategoryNotificationUpdateResponse(
+    val categoryId: Long?,
+    val categoryNotificationId: Long?,
+    val type: CategoryNotificationType,
+) {
+    companion object {
+        fun CategoryNotification.toCategoryNotificationUpdateResponse(categoryId: Long?): CategoryNotificationUpdateResponse {
+            return CategoryNotificationUpdateResponse(
+                categoryId = categoryId,
+                categoryNotificationId = this.id,
+                type = this.type
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/com/project/api/web/dto/response/CategoryUpdateResponse.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/response/CategoryUpdateResponse.kt
@@ -1,0 +1,20 @@
+package com.project.api.web.dto.response
+
+import com.project.core.domain.category.Category
+
+data class CategoryUpdateResponse(
+    val groupId: Long?,
+    val categoryId: Long?,
+    val name: String,
+    val isPublic: Boolean,
+) {
+    companion object {
+        fun Category.toCategoryUpdateResponse(groupId: Long?): CategoryUpdateResponse =
+            CategoryUpdateResponse(
+                groupId = groupId,
+                categoryId = this.id,
+                name = this.name,
+                isPublic = this.isPublic,
+            )
+    }
+}

--- a/api/src/test/kotlin/com/project/api/fixture/CategoryFixture.kt
+++ b/api/src/test/kotlin/com/project/api/fixture/CategoryFixture.kt
@@ -1,0 +1,27 @@
+package com.project.api.fixture
+
+import com.project.api.repository.category.CategoryNotificationRepository
+import com.project.api.repository.category.CategoryRepository
+import com.project.core.domain.category.Category
+import com.project.core.domain.group.Group
+import org.springframework.stereotype.Component
+import java.util.Random
+import java.util.UUID
+
+@Component
+class CategoryFixture(
+    private val categoryRepository: CategoryRepository,
+    private val categoryNotificationRepository: CategoryNotificationRepository,
+) : Fixture {
+
+    fun create(
+        name: String = UUID.randomUUID().toString(),
+        isPublic: Boolean = Random().nextBoolean(),
+        group: Group,
+    ) = categoryRepository.save(Category(name, isPublic, group))
+
+    override fun tearDown() {
+        categoryNotificationRepository.deleteAll()
+        categoryRepository.deleteAll()
+    }
+}

--- a/api/src/test/kotlin/com/project/api/fixture/GroupUserFixture.kt
+++ b/api/src/test/kotlin/com/project/api/fixture/GroupUserFixture.kt
@@ -30,4 +30,3 @@ class GroupUserFixture(
         groupUserRepository.deleteAll()
     }
 }
-

--- a/api/src/test/kotlin/com/project/api/fixture/UserFixture.kt
+++ b/api/src/test/kotlin/com/project/api/fixture/UserFixture.kt
@@ -2,12 +2,9 @@ package com.project.api.fixture
 
 import com.project.api.repository.user.UserRepository
 import com.project.core.domain.user.User
-import com.project.core.util.LocationUtil
-import org.locationtech.jts.geom.Point
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 import java.util.UUID
-import kotlin.random.Random
 
 @Component
 class UserFixture(
@@ -19,9 +16,6 @@ class UserFixture(
         password: String = "test",
         name: String = UUID.randomUUID().toString(),
         img: String? = null,
-        phoneNumber: String = "010-1234-1234",
-        description: String = "description",
-        point: Point = LocationUtil.createPoint(Random.nextDouble(139.0), Random.nextDouble(24.0)),
     ): User =
         userRepository.save(
             User(

--- a/api/src/test/kotlin/com/project/api/service/CategoryNotificationServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/CategoryNotificationServiceTest.kt
@@ -1,0 +1,153 @@
+package com.project.api.service
+
+import com.project.api.commons.exception.RestException
+import com.project.api.fixture.CategoryFixture
+import com.project.api.fixture.GroupFixture
+import com.project.api.fixture.GroupUserFixture
+import com.project.api.fixture.UserFixture
+import com.project.api.repository.category.CategoryNotificationRepository
+import com.project.api.repository.category.CategoryRepository
+import com.project.api.repository.group.GroupUserRepository
+import com.project.api.web.dto.request.CategoryNotificationUpdateRequest
+import com.project.core.domain.user.QUser.user
+import com.project.core.internal.CategoryNotificationType
+import com.project.core.internal.GroupRole
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CategoryNotificationServiceTest(
+    @Autowired private val categoryFixture: CategoryFixture,
+    @Autowired private val categoryService: CategoryService,
+    @Autowired private val groupFixture: GroupFixture,
+    @Autowired private val categoryNotificationRepository: CategoryNotificationRepository,
+    @Autowired private val userFixture: UserFixture,
+    @Autowired private val categoryRepository: CategoryRepository,
+    @Autowired private val groupUserFixture: GroupUserFixture,
+    @Autowired private val categoryNotificationService: CategoryNotificationService,
+    @Autowired private val groupUserRepository: GroupUserRepository,
+) {
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @AfterEach
+    fun tearDown() {
+        categoryFixture.tearDown()
+        groupFixture.tearDown()
+        userFixture.tearDown()
+    }
+
+    @Test
+    fun updateByEmail() {
+        val user = userFixture.create()
+        val group = groupFixture.create(user)
+        val category = categoryFixture.create(group = group)
+        val request =
+            CategoryNotificationUpdateRequest(
+                groupId = group.id!!,
+                categoryId = category.id!!,
+                type = CategoryNotificationType.NONE,
+            )
+
+        val response = categoryNotificationService.update(user.email, request)
+
+        Assertions.assertThat(response.categoryId).isEqualTo(category.id)
+        Assertions.assertThat(response.type).isEqualTo(request.type)
+    }
+
+    @Test
+    fun updateByEmailNotFoundGroup() {
+        val user = userFixture.create()
+        val request =
+            CategoryNotificationUpdateRequest(
+                groupId = 1L,
+                categoryId = 1L,
+                type = CategoryNotificationType.NONE,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryNotificationService.update(user.email, request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun updateByEmailNotFoundGroupUser() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        val category = categoryFixture.create(group = group)
+        val request =
+            CategoryNotificationUpdateRequest(
+                groupId = group.id!!,
+                categoryId = category.id!!,
+                type = CategoryNotificationType.NONE,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryNotificationService.update(user.email, request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun updateByEmailNotAllowedIfRoleIsNotTopAdmin() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        groupUserFixture.create(group = group, user = user, role = GroupRole.PENDING)
+        val category = categoryFixture.create(group = group)
+        val request =
+            CategoryNotificationUpdateRequest(
+                groupId = group.id!!,
+                categoryId = category.id!!,
+                type = CategoryNotificationType.NONE,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryNotificationService.update(user.email, request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun updateByEmailNotFoundCategory() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        groupUserFixture.create(group, user)
+        val request =
+            CategoryNotificationUpdateRequest(
+                groupId = group.id!!,
+                categoryId = 1L,
+                type = CategoryNotificationType.NONE,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryNotificationService.update(user.email, request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun updateByGroupUser() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val groupAdmin = groupUserRepository.findByUserAndGroup(admin, group)!!
+        val category = categoryFixture.create(group = group)
+
+        categoryNotificationService.update(group = group, groupUser = groupAdmin, type = CategoryNotificationType.MENTIONS)
+
+        val response = categoryNotificationRepository.findAll()
+        Assertions.assertThat(response).isNotEmpty
+        Assertions.assertThat(response[0].type).isEqualTo(CategoryNotificationType.MENTIONS)
+    }
+}

--- a/api/src/test/kotlin/com/project/api/service/CategoryServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/CategoryServiceTest.kt
@@ -1,0 +1,280 @@
+package com.project.api.service
+
+import com.project.api.commons.exception.RestException
+import com.project.api.fixture.CategoryFixture
+import com.project.api.fixture.GroupFixture
+import com.project.api.fixture.GroupUserFixture
+import com.project.api.fixture.UserFixture
+import com.project.api.repository.category.CategoryNotificationRepository
+import com.project.api.repository.category.CategoryRepository
+import com.project.api.web.dto.request.CategoryCreateRequest
+import com.project.api.web.dto.request.CategoryUpdateRequest
+import com.project.core.internal.CategoryNotificationType
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CategoryServiceTest(
+    @Autowired private val categoryFixture: CategoryFixture,
+    @Autowired private val categoryService: CategoryService,
+    @Autowired private val groupFixture: GroupFixture,
+    @Autowired private val categoryNotificationRepository: CategoryNotificationRepository,
+    @Autowired private val userFixture: UserFixture,
+    @Autowired private val categoryRepository: CategoryRepository,
+    @Autowired private val groupUserFixture: GroupUserFixture,
+) {
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @AfterEach
+    fun tearDown() {
+        categoryFixture.tearDown()
+        groupFixture.tearDown()
+        userFixture.tearDown()
+    }
+
+    @Test
+    fun create() {
+        val user = userFixture.create()
+        val group = groupFixture.create(user)
+        val request =
+            CategoryCreateRequest(
+                name = "category",
+                groupId = group.id!!,
+                isPublic = true,
+            )
+
+        val response =
+            categoryService.create(
+                email = user.email,
+                request = request,
+            )
+
+        val notificationResponse = categoryNotificationRepository.findAll()
+
+        Assertions.assertThat(response.name).isEqualTo(request.name)
+        Assertions.assertThat(response.groupId).isEqualTo(group.id)
+        Assertions.assertThat(response.isPublic).isEqualTo(request.isPublic)
+        Assertions.assertThat(notificationResponse).isNotEmpty
+        Assertions.assertThat(notificationResponse[0].type).isEqualTo(CategoryNotificationType.ALL)
+    }
+
+    @Test
+    fun createNotFoundGroup() {
+        val user = userFixture.create()
+        val request =
+            CategoryCreateRequest(
+                name = "category",
+                groupId = 1L,
+                isPublic = true,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.create(
+                    email = user.email,
+                    request = request,
+                )
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun createNotFoundGroupUser() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+
+        val request =
+            CategoryCreateRequest(
+                name = "category",
+                groupId = group.id!!,
+                isPublic = true,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.create(
+                    email = user.email,
+                    request = request,
+                )
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun createNotAllowedIfRoleIsNotTopAdmin() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        val groupUser = groupUserFixture.create(group = group, user = user)
+
+        val request =
+            CategoryCreateRequest(
+                name = "category",
+                groupId = group.id!!,
+                isPublic = true,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.create(email = user.email, request = request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun update() {
+        val user = userFixture.create()
+        val group = groupFixture.create(user)
+        val category = categoryFixture.create(group = group)
+        val request =
+            CategoryUpdateRequest(
+                name = "category",
+                groupId = group.id!!,
+                isPublic = true,
+                categoryId = category.id!!,
+            )
+
+        val response = categoryService.update(email = user.email, request = request)
+
+        Assertions.assertThat(response.name).isEqualTo(request.name)
+        Assertions.assertThat(response.groupId).isEqualTo(group.id)
+        Assertions.assertThat(response.isPublic).isEqualTo(request.isPublic)
+        Assertions.assertThat(response.categoryId).isEqualTo(category.id)
+    }
+
+    @Test
+    fun updateNotFoundGroup() {
+        val user = userFixture.create()
+        val request =
+            CategoryUpdateRequest(
+                name = "category",
+                groupId = 1L,
+                isPublic = true,
+                categoryId = 1L,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.update(email = user.email, request = request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun updateNotFoundGroupUser() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        val category = categoryFixture.create(group = group)
+        val request =
+            CategoryUpdateRequest(
+                name = "category",
+                groupId = group.id!!,
+                isPublic = true,
+                categoryId = category.id!!,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.update(email = user.email, request = request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun updateNotAllowedIfRoleIsNotTopAdmin() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        groupUserFixture.create(group = group, user = user)
+        val category = categoryFixture.create(group = group)
+        val request =
+            CategoryUpdateRequest(
+                name = "category",
+                groupId = group.id!!,
+                isPublic = true,
+                categoryId = category.id!!,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.update(email = user.email, request = request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun updateNotFoundCategory() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val request =
+            CategoryUpdateRequest(
+                name = "category",
+                groupId = group.id!!,
+                isPublic = true,
+                categoryId = 1L,
+            )
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.update(email = admin.email, request = request)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun delete() {
+        val user = userFixture.create()
+        val group = groupFixture.create(user)
+        val category = categoryFixture.create(group = group)
+
+        categoryService.delete(email = user.email, categoryId = category.id!!)
+
+        val categoryResponse = categoryRepository.findAll()
+        val notificationResponse = categoryNotificationRepository.findAll()
+
+        Assertions.assertThat(categoryResponse).isEmpty()
+        Assertions.assertThat(notificationResponse).isEmpty()
+    }
+
+    @Test
+    fun deleteNotFoundCategory() {
+        val user = userFixture.create()
+        val group = groupFixture.create(user)
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.delete(email = user.email, categoryId = 1L)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun deleteNotFoundGroupUser() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        val category = categoryFixture.create(group = group)
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.delete(email = user.email, categoryId = category.id!!)
+            }.isInstanceOf(RestException::class.java)
+    }
+
+    @Test
+    fun deleteNotAllowedIfRoleIsNotTopAdmin() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val user = userFixture.create()
+        groupUserFixture.create(group = group, user = user)
+        val category = categoryFixture.create(group = group)
+
+        Assertions
+            .assertThatThrownBy {
+                categoryService.delete(email = user.email, categoryId = category.id!!)
+            }.isInstanceOf(RestException::class.java)
+    }
+}

--- a/api/src/test/kotlin/com/project/api/service/GroupServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/GroupServiceTest.kt
@@ -221,4 +221,3 @@ class GroupServiceTest(
             }.isInstanceOf(RestException::class.java)
     }
 }
-

--- a/api/src/test/kotlin/com/project/api/service/GroupUserServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/GroupUserServiceTest.kt
@@ -597,4 +597,3 @@ class GroupUserServiceTest(
             }.isInstanceOf(RestException::class.java)
     }
 }
-

--- a/core/src/main/kotlin/com/project/core/domain/category/Category.kt
+++ b/core/src/main/kotlin/com/project/core/domain/category/Category.kt
@@ -1,0 +1,19 @@
+package com.project.core.domain.category
+
+import com.project.core.domain.BaseEntity
+import com.project.core.domain.group.Group
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+
+@Entity
+class Category(
+    var name: String,
+    var isPublic: Boolean = false,
+    @ManyToOne(fetch = FetchType.LAZY) val group: Group,
+) : BaseEntity() {
+    @OneToMany(mappedBy = "category", cascade = [CascadeType.REMOVE], orphanRemoval = true)
+    var categoryNotifications: MutableSet<CategoryNotification> = mutableSetOf()
+}

--- a/core/src/main/kotlin/com/project/core/domain/category/CategoryNotification.kt
+++ b/core/src/main/kotlin/com/project/core/domain/category/CategoryNotification.kt
@@ -1,0 +1,18 @@
+package com.project.core.domain.category
+
+import com.project.core.domain.BaseEntity
+import com.project.core.domain.group.GroupUser
+import com.project.core.internal.CategoryNotificationType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ManyToOne
+
+@Entity
+class CategoryNotification(
+    @ManyToOne(fetch = FetchType.LAZY) val category: Category,
+    @ManyToOne(fetch = FetchType.LAZY) val groupUser: GroupUser,
+    @Enumerated(value = EnumType.STRING)
+    var type: CategoryNotificationType = CategoryNotificationType.ALL,
+) : BaseEntity()

--- a/core/src/main/kotlin/com/project/core/domain/group/GroupUser.kt
+++ b/core/src/main/kotlin/com/project/core/domain/group/GroupUser.kt
@@ -18,7 +18,7 @@ import jakarta.persistence.UniqueConstraint
 )
 class GroupUser(
     @ManyToOne val user: User,
-    @ManyToOne @JoinColumn(name = "group_id")  val group: Group,
+    @ManyToOne @JoinColumn(name = "group_id") val group: Group,
     @Enumerated(value = EnumType.STRING)
     var role: GroupRole = GroupRole.PENDING,
 ) : BaseEntity() {

--- a/core/src/main/kotlin/com/project/core/internal/Enum.kt
+++ b/core/src/main/kotlin/com/project/core/internal/Enum.kt
@@ -14,4 +14,22 @@ enum class GroupRole {
             PENDING, SUSPENDED, INVITED -> false
             else -> true
         }
+
+    fun isAdmin(): Boolean =
+        when (this) {
+            TOP_MANAGER, MANAGER -> true
+            else -> false
+        }
+
+    fun isTopAmin(): Boolean =
+        when (this) {
+            TOP_MANAGER -> true
+            else -> false
+        }
+}
+
+enum class CategoryNotificationType {
+    ALL,
+    MENTIONS,
+    NONE,
 }


### PR DESCRIPTION
### 🔔 연관된 이슈

> ex) #이슈번호, #이슈번호
#29 

<br>

#### 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

카테고리및 카테고리 알림을 생성
- 카테고리는 그룹 주최자만 생성, 삭제, 수정 가능함
- 카테고리별 알림은 그룹 유저마다 설정가능함
- 그룹에 가입요청, 회원등급 수정, 정치처분 될때 그룹내 모든 카테고리 알림이 수정됨

<br>

#### 📷 스크린샷 (선택)
