### PR TITLE
[Feature #31] add group search and invitation

### DIFF
--- a/api/src/main/kotlin/com/project/api/internal/Enum.kt
+++ b/api/src/main/kotlin/com/project/api/internal/Enum.kt
@@ -9,6 +9,7 @@ enum class ErrorMessage(
     NOT_FOUND_GROUP("해당 그룹을 찾을 수 없습니다."),
     NOT_FOUND_GROUP_USER("해당 그룹 회원을 찾을 수 없습니다."),
     NOT_FOUND_CATEGORY("해당 카테고리를 찾을 수 없습니다."),
+    NOT_FOUND_NOTIFICATION("해당 알림을 찾을 수 없습니다."),
     NEW_PASSWORD_MATCH_OLD_PASSWORD("새로운 패스워드가 이전 패스워드와 일치합니다."),
     IMPOSSIBLE_LOGIN("로그인이 불가능합니다. 관리자에게 문의해주세요"),
     IMPOSSIBLE_PASSWORD("이전 비밀번호와 다른 비밀번호로 설정해주세요"),

--- a/api/src/main/kotlin/com/project/api/repository/group/GroupRepository.kt
+++ b/api/src/main/kotlin/com/project/api/repository/group/GroupRepository.kt
@@ -2,5 +2,8 @@ package com.project.api.repository.group
 
 import com.project.core.domain.group.Group
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
-interface GroupRepository : JpaRepository<Group, Long>
+interface GroupRepository :
+    JpaRepository<Group, Long>,
+    QuerydslPredicateExecutor<Group>

--- a/api/src/main/kotlin/com/project/api/repository/group/GroupUserRepository.kt
+++ b/api/src/main/kotlin/com/project/api/repository/group/GroupUserRepository.kt
@@ -3,6 +3,7 @@ package com.project.api.repository.group
 import com.project.core.domain.group.Group
 import com.project.core.domain.group.GroupUser
 import com.project.core.domain.user.User
+import com.project.core.internal.GroupRole
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
@@ -23,4 +24,9 @@ interface GroupUserRepository :
         id: Long,
         group: Group,
     ): GroupUser?
+
+    fun findByUserAndRole(
+        user: User,
+        role: GroupRole,
+    ): List<GroupUser>
 }

--- a/api/src/main/kotlin/com/project/api/repository/notification/NotificationRepository.kt
+++ b/api/src/main/kotlin/com/project/api/repository/notification/NotificationRepository.kt
@@ -1,0 +1,9 @@
+package com.project.api.repository.notification
+
+import com.project.core.domain.notification.Notification
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
+
+interface NotificationRepository :
+    JpaRepository<Notification, Long>,
+    QuerydslPredicateExecutor<Notification>

--- a/api/src/main/kotlin/com/project/api/service/GroupService.kt
+++ b/api/src/main/kotlin/com/project/api/service/GroupService.kt
@@ -11,7 +11,11 @@ import com.project.api.web.dto.response.GroupResponse
 import com.project.api.web.dto.response.GroupResponse.Companion.toResponse
 import com.project.core.domain.group.Group
 import com.project.core.domain.group.GroupUser
+import com.project.core.domain.group.QGroup
 import com.project.core.internal.GroupRole
+import com.querydsl.core.BooleanBuilder
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,6 +26,21 @@ class GroupService(
     private val groupUserRepository: GroupUserRepository,
     private val userRepository: UserRepository,
 ) {
+    fun readAll(
+        name: String?,
+        pageable: Pageable,
+    ): Page<GroupResponse> =
+        groupRepository
+            .findAll(
+                BooleanBuilder()
+                    .and(
+                        name?.let { QGroup.group.name.containsIgnoreCase(name) },
+                    ),
+                pageable,
+            ).map {
+                it.toResponse()
+            }
+
     fun readOne(
         email: String,
         groupId: Long,

--- a/api/src/main/kotlin/com/project/api/service/GroupUserService.kt
+++ b/api/src/main/kotlin/com/project/api/service/GroupUserService.kt
@@ -116,15 +116,21 @@ class GroupUserService(
     fun acceptInvitation(
         email: String,
         groupUserId: Long,
-    ): GroupUserResponse {
+        isAccepted: Boolean,
+    ) {
         val user = userRepository.findByEmail(email) ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
         val groupUser =
             groupUserRepository.findByIdOrNull(groupUserId) ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_GROUP_USER.message)
 
-        return groupUser
+        if (!isAccepted) {
+            groupUserRepository.delete(groupUser)
+            return
+        }
+
+        groupUser
             .apply {
                 this.role = GroupRole.USER
-            }.toGroupUserResponse()
+            }
     }
 
     @Transactional

--- a/api/src/main/kotlin/com/project/api/service/NotificationService.kt
+++ b/api/src/main/kotlin/com/project/api/service/NotificationService.kt
@@ -1,0 +1,87 @@
+package com.project.api.service
+
+import com.project.api.commons.exception.RestException
+import com.project.api.internal.ErrorMessage
+import com.project.api.repository.notification.NotificationRepository
+import com.project.api.repository.user.UserRepository
+import com.project.api.web.dto.response.NotificationResponse
+import com.project.api.web.dto.response.NotificationResponse.Companion.toResponse
+import com.project.core.domain.category.Category
+import com.project.core.domain.group.Group
+import com.project.core.domain.notification.Notification
+import com.project.core.domain.notification.QNotification
+import com.project.core.domain.user.User
+import com.project.core.internal.NotificationType
+import com.querydsl.core.BooleanBuilder
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NotificationService(
+    private val notificationRepository: NotificationRepository,
+    private val userRepository: UserRepository,
+) {
+    @Transactional
+    fun create(
+        user: User,
+        group: Group,
+        contentId: Long,
+        type: NotificationType,
+    ) {
+        notificationRepository.save(
+            Notification(
+                user = user,
+                group = group,
+                contentId = contentId,
+                type = type,
+            ),
+        )
+    }
+
+    fun readAll(
+        email: String,
+        isRead: Boolean?,
+        pageable: Pageable,
+    ): Page<NotificationResponse> =
+        notificationRepository
+            .findAll(
+                BooleanBuilder()
+                    .and(
+                        isRead?.let { QNotification.notification.isRead.eq(it) },
+                    ).and(
+                        QNotification.notification.user.email
+                            .eq(email),
+                    ),
+                pageable,
+            ).map {
+                it.toResponse(createNotificationContent(it.type, it.category, it.group))
+            }
+
+    @Transactional
+    fun update(notificationId: Long) {
+        val notification =
+            notificationRepository.findByIdOrNull(notificationId) ?: throw RestException.notFound(
+                ErrorMessage.NOT_FOUND_NOTIFICATION.message,
+            )
+
+        notification.apply {
+            this.isRead = true
+        }
+    }
+
+    private fun createNotificationContent(
+        type: NotificationType,
+        category: Category?,
+        group: Group,
+    ): String {
+        when (type) {
+            NotificationType.CONTENT -> return "${group.name}의 카테고리 ${category!!.name}에 새로운 컨텐츠가 게시되었습니다."
+            NotificationType.NOTICE -> return "${group.name}에 공지사항을 확인해주세요"
+            NotificationType.MENTION -> return "${group.name} 컨텐츠에 멘션되었습니다."
+            else -> return "${group.name}에서 초대장을 보냈습니다."
+        }
+    }
+}

--- a/api/src/main/kotlin/com/project/api/service/UserService.kt
+++ b/api/src/main/kotlin/com/project/api/service/UserService.kt
@@ -8,14 +8,15 @@ import com.project.api.repository.user.UserRepository
 import com.project.api.web.dto.request.UserCreateRequest
 import com.project.api.web.dto.request.UserLoginRequest
 import com.project.api.web.dto.request.UserResetPasswordRequest
-import com.project.api.web.dto.request.UserResponse
-import com.project.api.web.dto.request.UserResponse.Companion.toUserResponse
 import com.project.api.web.dto.request.UserUpdateRequest
 import com.project.api.web.dto.response.TokenResponse
 import com.project.api.web.dto.response.UserLoginResponse
 import com.project.api.web.dto.response.UserLoginResponse.Companion.toUserLoginResponse
+import com.project.api.web.dto.response.UserResponse
+import com.project.api.web.dto.response.UserResponse.Companion.toUserResponse
 import com.project.core.domain.user.User
 import com.project.core.domain.user.UserHashTag
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -127,6 +128,13 @@ class UserService(
 
     @Transactional
     fun createToken(email: String): TokenResponse = authService.create(email)
+
+    fun readOne(userId: Long): UserResponse {
+        val user =
+            userRepository.findByIdOrNull(userId) ?: throw RestException.notFound(ErrorMessage.NOT_FOUND_USER.message)
+
+        return user.toUserResponse()
+    }
 
     private fun updateUser(
         request: UserUpdateRequest,

--- a/api/src/main/kotlin/com/project/api/web/api/GroupController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/GroupController.kt
@@ -6,12 +6,15 @@ import com.project.api.web.dto.request.GroupUpdateRequest
 import com.project.api.web.dto.response.GroupResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,10 +28,17 @@ class GroupController(
     private val groupService: GroupService,
 ) {
     @GetMapping
+    @Operation(summary = "그룹 검색")
+    fun readAll(
+        @ParameterObject pageable: Pageable,
+        @RequestParam name: String?,
+    ) = groupService.readAll(name, pageable)
+
+    @GetMapping("{groupId}")
     @Operation(summary = "각 그룹 조회")
     fun readOne(
         @AuthenticationPrincipal jwt: Jwt,
-        @RequestParam groupId: Long,
+        @PathVariable groupId: Long,
     ): GroupResponse = groupService.readOne(jwt.subject, groupId)
 
     @PostMapping

--- a/api/src/main/kotlin/com/project/api/web/api/GroupUserController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/GroupUserController.kt
@@ -2,6 +2,7 @@ package com.project.api.web.api
 
 import com.project.api.service.GroupUserService
 import com.project.api.web.dto.request.GroupUserCreateRequest
+import com.project.api.web.dto.request.GroupUserInvitationRequest
 import com.project.api.web.dto.request.GroupUserUpdateRequest
 import com.project.api.web.dto.response.GroupRoleResponse
 import com.project.api.web.dto.response.GroupUserCreateResponse
@@ -18,6 +19,7 @@ import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -31,11 +33,31 @@ class GroupUserController(
     private val groupUserService: GroupUserService,
 ) {
     @PostMapping("join")
-    @Operation(summary = "가입요청")
+    @Operation(summary = "가입요청(role = Pending)")
     fun create(
         @AuthenticationPrincipal jwt: Jwt,
         @RequestBody request: GroupUserCreateRequest,
     ): GroupUserCreateResponse = groupUserService.create(jwt.subject, request)
+
+    @PostMapping("/invitations")
+    @Operation(summary = "그룹에 초대하기(role= INVITED)")
+    fun createInvitation(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestBody request: GroupUserInvitationRequest,
+    ) = groupUserService.createInvitation(jwt.subject, request)
+
+    @GetMapping("/invitations")
+    @Operation(summary = "그룹 초대 확인")
+    fun readInvitations(
+        @AuthenticationPrincipal jwt: Jwt,
+    ) = groupUserService.readInvitations(jwt.subject)
+
+    @PatchMapping("/invitations/{groupUserId}")
+    @Operation(summary = "그룹 초대 수락")
+    fun acceptInvitation(
+        @AuthenticationPrincipal jwt: Jwt,
+        @PathVariable groupUserId: Long,
+    ) = groupUserService.acceptInvitation(jwt.subject, groupUserId)
 
     @PatchMapping("role/update")
     @Operation(summary = "가입요청 승인 및 회원 등급 수정 및 정지처분")

--- a/api/src/main/kotlin/com/project/api/web/api/GroupUserController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/GroupUserController.kt
@@ -19,7 +19,6 @@ import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -52,12 +51,16 @@ class GroupUserController(
         @AuthenticationPrincipal jwt: Jwt,
     ) = groupUserService.readInvitations(jwt.subject)
 
-    @PatchMapping("/invitations/{groupUserId}")
-    @Operation(summary = "그룹 초대 수락")
-    fun acceptInvitation(
+    @PatchMapping("/invitations")
+    @Operation(summary = "그룹 초대 수락 or 거절")
+    fun updateInvitation(
         @AuthenticationPrincipal jwt: Jwt,
-        @PathVariable groupUserId: Long,
-    ) = groupUserService.acceptInvitation(jwt.subject, groupUserId)
+        @RequestParam groupUserId: Long,
+        @RequestParam isAccepted: Boolean,
+    ): ResponseEntity<Unit> {
+        groupUserService.acceptInvitation(jwt.subject, groupUserId, isAccepted)
+        return ResponseEntity.accepted().build()
+    }
 
     @PatchMapping("role/update")
     @Operation(summary = "가입요청 승인 및 회원 등급 수정 및 정지처분")

--- a/api/src/main/kotlin/com/project/api/web/api/NotificationController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/NotificationController.kt
@@ -1,0 +1,37 @@
+package com.project.api.web.api
+
+import com.project.api.service.NotificationService
+import io.swagger.v3.oas.annotations.Operation
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Pageable
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/notifications")
+class NotificationController(
+    private val notificationService: NotificationService,
+) {
+    @GetMapping
+    @Operation(summary = "모든 알림 읽기")
+    fun readAll(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestParam isRead: Boolean?,
+        @ParameterObject pageable: Pageable,
+    ) = notificationService.readAll(
+        email = jwt.subject,
+        isRead = isRead,
+        pageable = pageable,
+    )
+
+    @PatchMapping
+    @Operation(summary = "알림 읽음으로 변경")
+    fun update(
+        @RequestParam notificationId: Long,
+    ) = notificationService.update(notificationId)
+}

--- a/api/src/main/kotlin/com/project/api/web/api/UserController.kt
+++ b/api/src/main/kotlin/com/project/api/web/api/UserController.kt
@@ -4,10 +4,10 @@ import com.project.api.service.UserService
 import com.project.api.web.dto.request.UserCreateRequest
 import com.project.api.web.dto.request.UserLoginRequest
 import com.project.api.web.dto.request.UserResetPasswordRequest
-import com.project.api.web.dto.request.UserResponse
 import com.project.api.web.dto.request.UserUpdateRequest
 import com.project.api.web.dto.response.TokenResponse
 import com.project.api.web.dto.response.UserLoginResponse
+import com.project.api.web.dto.response.UserResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -16,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -79,4 +80,10 @@ class UserController(
     fun createToken(
         @AuthenticationPrincipal jwt: Jwt,
     ): TokenResponse = userService.createToken(jwt.subject)
+
+    @GetMapping("{userId}")
+    @Operation(summary = "한 회원 검색")
+    fun readOne(
+        @PathVariable userId: Long,
+    ): UserResponse = userService.readOne(userId)
 }

--- a/api/src/main/kotlin/com/project/api/web/dto/request/GroupUserCreateRequest.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/request/GroupUserCreateRequest.kt
@@ -1,6 +1,9 @@
 package com.project.api.web.dto.request
 
+import com.project.core.internal.GroupRole
+
 data class GroupUserCreateRequest(
     val groupId: Long,
     val name: String?,
+    val role: GroupRole,
 )

--- a/api/src/main/kotlin/com/project/api/web/dto/request/GroupUserInvitationRequest.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/request/GroupUserInvitationRequest.kt
@@ -1,0 +1,6 @@
+package com.project.api.web.dto.request
+
+data class GroupUserInvitationRequest(
+    val groupId: Long,
+    val userId: Long,
+)

--- a/api/src/main/kotlin/com/project/api/web/dto/response/GroupInvitationResponse.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/response/GroupInvitationResponse.kt
@@ -1,0 +1,21 @@
+package com.project.api.web.dto.response
+
+import com.project.core.domain.group.GroupUser
+import com.project.core.internal.GroupRole
+
+data class GroupInvitationResponse(
+    val groupName: String,
+    val groupId: Long?,
+    val groupUserId: Long?,
+    val role: GroupRole,
+) {
+    companion object {
+        fun GroupUser.toGroupInvitationResponse(): GroupInvitationResponse =
+            GroupInvitationResponse(
+                groupName = this.group.name,
+                groupId = this.group.id,
+                groupUserId = this.id,
+                role = this.role,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/project/api/web/dto/response/NotificationResponse.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/response/NotificationResponse.kt
@@ -1,0 +1,25 @@
+package com.project.api.web.dto.response
+
+import com.project.core.domain.notification.Notification
+import com.project.core.internal.NotificationType
+
+data class NotificationResponse(
+    val type: NotificationType,
+    val notificationId: Long?,
+    val groupId: Long?,
+    val contentId: Long,
+    val content: String,
+    val isRead: Boolean,
+) {
+    companion object {
+        fun Notification.toResponse(content: String): NotificationResponse =
+            NotificationResponse(
+                type = this.type,
+                notificationId = this.id,
+                groupId = this.group.id,
+                contentId = this.contentId,
+                content = content,
+                isRead = this.isRead,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/project/api/web/dto/response/UserResponse.kt
+++ b/api/src/main/kotlin/com/project/api/web/dto/response/UserResponse.kt
@@ -1,4 +1,4 @@
-package com.project.api.web.dto.request
+package com.project.api.web.dto.response
 
 import com.project.core.domain.user.User
 

--- a/api/src/test/kotlin/com/project/api/fixture/CategoryFixture.kt
+++ b/api/src/test/kotlin/com/project/api/fixture/CategoryFixture.kt
@@ -13,7 +13,6 @@ class CategoryFixture(
     private val categoryRepository: CategoryRepository,
     private val categoryNotificationRepository: CategoryNotificationRepository,
 ) : Fixture {
-
     fun create(
         name: String = UUID.randomUUID().toString(),
         isPublic: Boolean = Random().nextBoolean(),

--- a/api/src/test/kotlin/com/project/api/fixture/NotificationFixture.kt
+++ b/api/src/test/kotlin/com/project/api/fixture/NotificationFixture.kt
@@ -1,0 +1,37 @@
+package com.project.api.fixture
+
+import com.project.api.repository.notification.NotificationRepository
+import com.project.core.domain.category.Category
+import com.project.core.domain.group.Group
+import com.project.core.domain.notification.Notification
+import com.project.core.domain.user.User
+import com.project.core.internal.NotificationType
+import org.springframework.stereotype.Component
+import kotlin.random.Random
+
+@Component
+class NotificationFixture(
+    private val notificationRepository: NotificationRepository,
+) : Fixture {
+    fun create(
+        user: User,
+        type: NotificationType = NotificationType.entries.random(),
+        group: Group,
+        contentId: Long = Random.nextLong(),
+        category: Category? = null,
+    ): Notification =
+        notificationRepository.save(
+            Notification(
+                user = user,
+                type = type,
+                group = group,
+                contentId = contentId,
+            ).apply {
+                this.category = category
+            },
+        )
+
+    override fun tearDown() {
+        notificationRepository.deleteAll()
+    }
+}

--- a/api/src/test/kotlin/com/project/api/service/GroupServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/GroupServiceTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.Pageable
 import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
@@ -32,6 +33,20 @@ class GroupServiceTest(
         groupUserFixture.tearDown()
         groupFixture.tearDown()
         userFixture.tearDown()
+    }
+
+    @Test
+    fun readAll() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+
+        val response = groupService.readAll(null, Pageable.unpaged())
+
+        Assertions.assertThat(response).isNotEmpty
+        Assertions.assertThat(response.first().name).isEqualTo(group.name)
+        Assertions.assertThat(response.first().description).isEqualTo(group.description)
+        Assertions.assertThat(response.first().id).isEqualTo(group.id)
+        Assertions.assertThat(response.first().isPublic).isEqualTo(group.isPublic)
     }
 
     @Test

--- a/api/src/test/kotlin/com/project/api/service/GroupUserServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/GroupUserServiceTest.kt
@@ -174,39 +174,40 @@ class GroupUserServiceTest(
     }
 
     @Test
-    fun acceptInvitation() {
+    fun updateInvitation() {
         val admin = userFixture.create()
         val group = groupFixture.create(admin)
         val joinUser = userFixture.create()
         val groupUser = groupUserFixture.create(group = group, user = joinUser, role = GroupRole.INVITED)
 
-        val response = groupUserService.acceptInvitation(joinUser.email, groupUser.id!!)
+        groupUserService.acceptInvitation(joinUser.email, groupUser.id!!, true)
 
-        Assertions.assertThat(response.groupUserId).isEqualTo(groupUser.id)
+        val response = groupUserRepository.findByUserAndGroup(joinUser, group)
+        Assertions.assertThat(response!!.id).isEqualTo(groupUser.id)
         Assertions.assertThat(response.role).isEqualTo(GroupRole.USER)
         Assertions.assertThat(response.name).isEqualTo(groupUser.name)
     }
 
     @Test
-    fun acceptInvitationNotFoundUser() {
+    fun updateInvitationNotFoundUser() {
         val admin = userFixture.create()
         val group = groupFixture.create(admin)
 
         Assertions
             .assertThatThrownBy {
-                groupUserService.acceptInvitation("test@kakao.com", 1L)
+                groupUserService.acceptInvitation("test@kakao.com", 1L, true)
             }.isInstanceOf(RestException::class.java)
     }
 
     @Test
-    fun acceptInvitationNotFoundGroupUser() {
+    fun updateInvitationNotFoundGroupUser() {
         val admin = userFixture.create()
         val group = groupFixture.create(admin)
         val joinUser = userFixture.create()
 
         Assertions
             .assertThatThrownBy {
-                groupUserService.acceptInvitation(joinUser.email, 100L)
+                groupUserService.acceptInvitation(joinUser.email, 100L, true)
             }.isInstanceOf(RestException::class.java)
     }
 

--- a/api/src/test/kotlin/com/project/api/service/GroupUserServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/GroupUserServiceTest.kt
@@ -48,6 +48,7 @@ class GroupUserServiceTest(
             GroupUserCreateRequest(
                 groupId = group.id!!,
                 name = null,
+                role = GroupRole.USER,
             )
 
         val response = groupUserService.create(joinUser.email, request)
@@ -63,6 +64,7 @@ class GroupUserServiceTest(
             GroupUserCreateRequest(
                 groupId = 1L,
                 name = null,
+                role = GroupRole.USER,
             )
 
         Assertions
@@ -83,6 +85,7 @@ class GroupUserServiceTest(
             GroupUserCreateRequest(
                 groupId = group.id!!,
                 name = null,
+                role = GroupRole.USER,
             )
 
         Assertions

--- a/api/src/test/kotlin/com/project/api/service/NotificationServiceTest.kt
+++ b/api/src/test/kotlin/com/project/api/service/NotificationServiceTest.kt
@@ -1,0 +1,154 @@
+package com.project.api.service
+
+import com.project.api.commons.exception.RestException
+import com.project.api.fixture.CategoryFixture
+import com.project.api.fixture.GroupFixture
+import com.project.api.fixture.GroupUserFixture
+import com.project.api.fixture.NotificationFixture
+import com.project.api.fixture.UserFixture
+import com.project.api.repository.notification.NotificationRepository
+import com.project.core.internal.NotificationType
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.Pageable
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NotificationServiceTest(
+    @Autowired private val notificationFixture: NotificationFixture,
+    @Autowired private val userFixture: UserFixture,
+    @Autowired private val groupFixture: GroupFixture,
+    @Autowired private val groupUserFixture: GroupUserFixture,
+    @Autowired private val notificationService: NotificationService,
+    @Autowired private val notificationRepository: NotificationRepository,
+    @Autowired private val categoryFixture: CategoryFixture,
+) {
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @AfterEach
+    fun tearDown() {
+        notificationFixture.tearDown()
+        groupUserFixture.tearDown()
+        categoryFixture.tearDown()
+        groupFixture.tearDown()
+        userFixture.tearDown()
+    }
+
+    @Test
+    fun create() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+
+        val notificationUser = userFixture.create()
+        val groupUser = groupUserFixture.create(group = group, user = notificationUser)
+        notificationService.create(
+            user = notificationUser,
+            group = group,
+            contentId = groupUser.id!!,
+            type = NotificationType.INVITATION,
+        )
+
+        val response = notificationRepository.findAll()
+
+        Assertions.assertThat(response).isNotEmpty
+        Assertions.assertThat(response[0].user.id).isEqualTo(notificationUser.id)
+        Assertions.assertThat(response[0].group.id).isEqualTo(group.id)
+        Assertions.assertThat(response[0].type).isEqualTo(NotificationType.INVITATION)
+    }
+
+    @Test
+    fun readAllWhenTypeIsNoticeAndContent() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val category = categoryFixture.create(group = group)
+        val notificationUser = userFixture.create()
+        val notification1 =
+            notificationFixture.create(
+                user = notificationUser,
+                group = group,
+                type = NotificationType.NOTICE,
+            )
+
+        notificationFixture.create(
+            user = notificationUser,
+            group = group,
+            type = NotificationType.CONTENT,
+            category = category,
+        )
+
+        val response =
+            notificationService.readAll(
+                email = notificationUser.email,
+                isRead = null,
+                pageable = Pageable.unpaged(),
+            )
+
+        Assertions.assertThat(response.size).isEqualTo(2)
+    }
+
+    @Test
+    fun readAllWhenTypeIsMentionAndInvitation() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val notificationUser = userFixture.create()
+        val notification1 =
+            notificationFixture.create(
+                user = notificationUser,
+                group = group,
+                type = NotificationType.MENTION,
+            )
+
+        notificationFixture.create(
+            user = notificationUser,
+            group = group,
+            type = NotificationType.INVITATION,
+        )
+
+        val response =
+            notificationService.readAll(
+                email = notificationUser.email,
+                isRead = null,
+                pageable = Pageable.unpaged(),
+            )
+
+        Assertions.assertThat(response.size).isEqualTo(2)
+    }
+
+    @Test
+    fun update() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val notificationUser = userFixture.create()
+        val notification =
+            notificationFixture.create(
+                user = notificationUser,
+                group = group,
+            )
+
+        notificationService.update(notification.id!!)
+
+        val response = notificationRepository.findAll()
+
+        Assertions.assertThat(response).isNotEmpty
+        Assertions.assertThat(response[0].isRead).isTrue()
+    }
+
+    @Test
+    fun updateNotFoundNotification() {
+        val admin = userFixture.create()
+        val group = groupFixture.create(admin)
+        val notificationUser = userFixture.create()
+
+        Assertions
+            .assertThatThrownBy {
+                notificationService.update(1L)
+            }.isInstanceOf(RestException::class.java)
+    }
+}

--- a/core/src/main/kotlin/com/project/core/domain/group/GroupLog.kt
+++ b/core/src/main/kotlin/com/project/core/domain/group/GroupLog.kt
@@ -1,3 +1,3 @@
 package com.project.core.domain.group
 
-class Log
+class GroupLog

--- a/core/src/main/kotlin/com/project/core/domain/notification/Notification.kt
+++ b/core/src/main/kotlin/com/project/core/domain/notification/Notification.kt
@@ -1,0 +1,25 @@
+package com.project.core.domain.notification
+
+import com.project.core.domain.BaseEntity
+import com.project.core.domain.category.Category
+import com.project.core.domain.group.Group
+import com.project.core.domain.user.User
+import com.project.core.internal.NotificationType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ManyToOne
+
+@Entity
+class Notification(
+    @ManyToOne(fetch = FetchType.LAZY) val user: User,
+    @Enumerated(value = EnumType.STRING) val type: NotificationType,
+    @ManyToOne(fetch = FetchType.LAZY) val group: Group,
+    val contentId: Long,
+) : BaseEntity() {
+    var isRead = false
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var category: Category? = null
+}

--- a/core/src/main/kotlin/com/project/core/internal/Enum.kt
+++ b/core/src/main/kotlin/com/project/core/internal/Enum.kt
@@ -33,3 +33,10 @@ enum class CategoryNotificationType {
     MENTIONS,
     NONE,
 }
+
+enum class NotificationType {
+    CONTENT,
+    MENTION,
+    INVITATION,
+    NOTICE,
+}


### PR DESCRIPTION
### 🔔 연관된 이슈

> ex) #이슈번호, #이슈번호
#31 

<br>

#### 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

그룹 검색 및 초대
- 이름 기준으로 그룹을 검색
- 초대장이 알림으로 발송 
- 초대에 대한 수락, 거절
  - 수락 시 : role -> user
  - 거절 시 : groupUser delete 

<br>

#### 📷 스크린샷 (선택)
